### PR TITLE
Implement property listing endpoints with validation

### DIFF
--- a/property-search-brisbane/backend/__tests__/properties.test.js
+++ b/property-search-brisbane/backend/__tests__/properties.test.js
@@ -1,0 +1,94 @@
+const request = require('supertest');
+const app = require('../server');
+
+describe('Property routes', () => {
+  describe('GET /properties', () => {
+    it('returns a paginated list of properties', async () => {
+      const response = await request(app).get('/properties');
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body.data)).toBe(true);
+      expect(response.body.pagination).toMatchObject({
+        page: 1,
+        pageSize: 20,
+      });
+      expect(typeof response.body.pagination.total).toBe('number');
+      response.body.data.forEach((property) => {
+        expect(property).toMatchObject({
+          id: expect.any(String),
+          address: expect.any(String),
+          price: expect.any(Number),
+          bedrooms: expect.any(Number),
+          bathrooms: expect.any(Number),
+          parking: expect.any(Number),
+        });
+      });
+    });
+
+    it('filters properties by suburb and price range', async () => {
+      const response = await request(app)
+        .get('/properties')
+        .query({ suburb: 'West End', minPrice: 800000, maxPrice: 900000 });
+
+      expect(response.status).toBe(200);
+      expect(response.body.data.length).toBeGreaterThan(0);
+      response.body.data.forEach((property) => {
+        expect(property.address).toContain('West End');
+        expect(property.price).toBeGreaterThanOrEqual(800000);
+        expect(property.price).toBeLessThanOrEqual(900000);
+      });
+    });
+
+    it('returns a validation error for invalid page', async () => {
+      const response = await request(app).get('/properties').query({ page: 0 });
+
+      expect(response.status).toBe(400);
+      expect(response.body).toEqual({
+        error: {
+          code: 'INVALID_REQUEST',
+          message: 'page must be a positive integer when provided.',
+        },
+      });
+    });
+
+    it('returns a validation error when minPrice is not a number', async () => {
+      const response = await request(app)
+        .get('/properties')
+        .query({ minPrice: 'abc' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toEqual({
+        code: 'INVALID_REQUEST',
+        message: 'minPrice must be a valid number.',
+      });
+    });
+  });
+
+  describe('GET /properties/:id', () => {
+    it('returns a property when it exists', async () => {
+      const response = await request(app).get('/properties/prop_001');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({
+        id: 'prop_001',
+        address: expect.any(String),
+        price: expect.any(Number),
+        bedrooms: expect.any(Number),
+        bathrooms: expect.any(Number),
+        parking: expect.any(Number),
+        description: expect.any(String),
+      });
+    });
+
+    it('returns not found when property does not exist', async () => {
+      const response = await request(app).get('/properties/unknown');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        error: {
+          code: 'RESOURCE_NOT_FOUND',
+          message: 'Property not found.',
+        },
+      });
+    });
+  });
+});

--- a/property-search-brisbane/backend/data/properties.json
+++ b/property-search-brisbane/backend/data/properties.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "prop_001",
+    "address": "123 Boundary St, West End",
+    "suburb": "West End",
+    "price": 850000,
+    "bedrooms": 3,
+    "bathrooms": 2,
+    "parking": 1,
+    "description": "Stylish inner-city apartment with river views."
+  },
+  {
+    "id": "prop_002",
+    "address": "45 James St, Fortitude Valley",
+    "suburb": "Fortitude Valley",
+    "price": 1200000,
+    "bedrooms": 4,
+    "bathrooms": 3,
+    "parking": 2,
+    "description": "Contemporary family home close to cafes and boutiques."
+  },
+  {
+    "id": "prop_003",
+    "address": "78 Latrobe Tce, Paddington",
+    "suburb": "Paddington",
+    "price": 720000,
+    "bedrooms": 2,
+    "bathrooms": 1,
+    "parking": 1,
+    "description": "Character cottage with city views and leafy surrounds."
+  },
+  {
+    "id": "prop_004",
+    "address": "9 Grey St, South Brisbane",
+    "suburb": "South Brisbane",
+    "price": 950000,
+    "bedrooms": 3,
+    "bathrooms": 2,
+    "parking": 1,
+    "description": "Spacious riverside apartment steps from cultural precinct."
+  }
+]

--- a/property-search-brisbane/backend/jest.config.js
+++ b/property-search-brisbane/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.js'],
+  collectCoverage: false,
+};

--- a/property-search-brisbane/backend/package.json
+++ b/property-search-brisbane/backend/package.json
@@ -5,13 +5,16 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "test": "jest"
   },
   "dependencies": {
     "dotenv": "^16.3.1",
     "express": "^4.18.2"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "jest": "^29.7.0",
+    "nodemon": "^3.0.1",
+    "supertest": "^6.3.4"
   }
 }

--- a/property-search-brisbane/backend/server.js
+++ b/property-search-brisbane/backend/server.js
@@ -1,15 +1,188 @@
 require('dotenv').config();
 const express = require('express');
+const {
+  searchProperties,
+  getPropertyById,
+  PropertyNotFoundError,
+  PAGE_SIZE,
+} = require('./services/propertyService');
+
 const app = express();
 
 const PORT = process.env.PORT || 3000;
+const ERROR_CODES = {
+  INVALID_REQUEST: 'INVALID_REQUEST',
+  NOT_FOUND: 'RESOURCE_NOT_FOUND',
+  INTERNAL: 'INTERNAL_SERVER_ERROR',
+};
 
 app.use(express.json());
+
+function respondWithError(res, status, code, message) {
+  return res.status(status).json({
+    error: {
+      code,
+      message,
+    },
+  });
+}
+
+function parseNumericQuery(value, field) {
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${field} must be a valid number.`);
+  }
+  return parsed;
+}
 
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+app.get('/properties', (req, res, next) => {
+  try {
+    const { suburb, minPrice, maxPrice, page } = req.query;
+    const filters = {};
+
+    if (suburb !== undefined) {
+      if (typeof suburb !== 'string' || !suburb.trim()) {
+        return respondWithError(
+          res,
+          400,
+          ERROR_CODES.INVALID_REQUEST,
+          'suburb must be a non-empty string when provided.'
+        );
+      }
+      filters.suburb = suburb.trim();
+    }
+
+    if (minPrice !== undefined) {
+      const value = parseNumericQuery(minPrice, 'minPrice');
+      if (value < 0) {
+        return respondWithError(
+          res,
+          400,
+          ERROR_CODES.INVALID_REQUEST,
+          'minPrice must be greater than or equal to 0.'
+        );
+      }
+      filters.minPrice = value;
+    }
+
+    if (maxPrice !== undefined) {
+      const value = parseNumericQuery(maxPrice, 'maxPrice');
+      if (value < 0) {
+        return respondWithError(
+          res,
+          400,
+          ERROR_CODES.INVALID_REQUEST,
+          'maxPrice must be greater than or equal to 0.'
+        );
+      }
+      filters.maxPrice = value;
+    }
+
+    if (
+      filters.minPrice !== undefined &&
+      filters.maxPrice !== undefined &&
+      filters.minPrice > filters.maxPrice
+    ) {
+      return respondWithError(
+        res,
+        400,
+        ERROR_CODES.INVALID_REQUEST,
+        'minPrice cannot be greater than maxPrice.'
+      );
+    }
+
+    if (page !== undefined) {
+      const value = parseNumericQuery(page, 'page');
+      if (!Number.isInteger(value) || value < 1) {
+        return respondWithError(
+          res,
+          400,
+          ERROR_CODES.INVALID_REQUEST,
+          'page must be a positive integer when provided.'
+        );
+      }
+      filters.page = value;
+    } else {
+      filters.page = 1;
+    }
+
+    const { results, pagination } = searchProperties({
+      suburb: filters.suburb,
+      minPrice: filters.minPrice,
+      maxPrice: filters.maxPrice,
+      page: filters.page,
+      pageSize: PAGE_SIZE,
+    });
+
+    const data = results.map((property) => ({
+      id: property.id,
+      address: property.address,
+      price: property.price,
+      bedrooms: property.bedrooms,
+      bathrooms: property.bathrooms,
+      parking: property.parking,
+    }));
+
+    return res.json({
+      data,
+      pagination,
+    });
+  } catch (error) {
+    if (error.message && error.message.includes('must be a valid number')) {
+      return respondWithError(
+        res,
+        400,
+        ERROR_CODES.INVALID_REQUEST,
+        error.message
+      );
+    }
+    return next(error);
+  }
 });
+
+app.get('/properties/:id', (req, res, next) => {
+  try {
+    const property = getPropertyById(req.params.id);
+    return res.json({
+      id: property.id,
+      address: property.address,
+      price: property.price,
+      bedrooms: property.bedrooms,
+      bathrooms: property.bathrooms,
+      parking: property.parking,
+      description: property.description,
+    });
+  } catch (error) {
+    if (error instanceof PropertyNotFoundError) {
+      return respondWithError(
+        res,
+        404,
+        ERROR_CODES.NOT_FOUND,
+        'Property not found.'
+      );
+    }
+    return next(error);
+  }
+});
+
+app.use((err, req, res, next) => {
+  console.error(err); // eslint-disable-line no-console
+  return respondWithError(
+    res,
+    err.status || 500,
+    err.code || ERROR_CODES.INTERNAL,
+    err.message || 'An unexpected error occurred.'
+  );
+});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/property-search-brisbane/backend/services/propertyService.js
+++ b/property-search-brisbane/backend/services/propertyService.js
@@ -1,0 +1,63 @@
+const properties = require('../data/properties.json');
+
+class PropertyNotFoundError extends Error {
+  constructor(message = 'Property not found.') {
+    super(message);
+    this.name = 'PropertyNotFoundError';
+  }
+}
+
+const PAGE_SIZE = 20;
+
+function normaliseSuburb(suburb) {
+  return suburb.trim().toLowerCase();
+}
+
+function searchProperties({ suburb, minPrice, maxPrice, page = 1, pageSize = PAGE_SIZE }) {
+  let filtered = properties;
+
+  if (suburb) {
+    const target = normaliseSuburb(suburb);
+    filtered = filtered.filter((property) => normaliseSuburb(property.suburb) === target);
+  }
+
+  if (typeof minPrice === 'number') {
+    filtered = filtered.filter((property) => property.price >= minPrice);
+  }
+
+  if (typeof maxPrice === 'number') {
+    filtered = filtered.filter((property) => property.price <= maxPrice);
+  }
+
+  const total = filtered.length;
+  const size = pageSize;
+  const start = (page - 1) * size;
+  const end = start + size;
+  const results = filtered.slice(start, end);
+
+  return {
+    results,
+    pagination: {
+      page,
+      pageSize: size,
+      total,
+    },
+  };
+}
+
+function getPropertyById(id) {
+  const property = properties.find((item) => item.id === id);
+
+  if (!property) {
+    throw new PropertyNotFoundError();
+  }
+
+  return property;
+}
+
+module.exports = {
+  searchProperties,
+  getPropertyById,
+  PropertyNotFoundError,
+  PAGE_SIZE,
+};


### PR DESCRIPTION
## Summary
- load property data through a service layer and expose search helpers
- add GET /properties and GET /properties/:id routes with validation and error handling
- document automated tests for the new endpoints

## Testing
- npm test *(fails: jest not found in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7c6df0848327afe9a6c19a969e3a