### PR TITLE
Add Queensland geocoding integration to property search

### DIFF
--- a/property-search-brisbane/backend/README.md
+++ b/property-search-brisbane/backend/README.md
@@ -13,10 +13,15 @@ This package implements the backend API for the Property Search Brisbane applica
    ```bash
    npm install
    ```
-2. Copy `.env.example` to `.env` and fill in the required values:
+2. Create a `.env` file with the required configuration values:
    ```bash
-   cp .env.example .env
+   cat <<'ENV' > .env
+   PORT=3000
+   GEOCODING_API_URL=https://api.qld.gov.au/example/geocoder
+   GEOCODING_API_KEY=your-api-key
+   ENV
    ```
+   Replace the example values with the real Queensland Government Geocoding API endpoint and key for your environment.
 3. Run the development server:
    ```bash
    npm run dev
@@ -32,7 +37,15 @@ The service exposes a `/health` endpoint for simple uptime checks.
 
 - `server.js` – Express entry point
 - `package.json` – project metadata and scripts
-- `.env.example` – template for environment configuration
+- `.env` – environment configuration (see below)
+
+## Configuration
+
+The backend relies on the Queensland Government Geocoding API to resolve addresses. Set the following environment variables either in `.env` or through your hosting provider:
+
+- `GEOCODING_API_URL` – Base URL for the Queensland Government Geocoding API endpoint.
+- `GEOCODING_API_KEY` – API key provisioned for your Queensland Government account.
+- `PORT` – Optional. Port for the Express server (defaults to `3000`).
 
 ## Scripts
 

--- a/property-search-brisbane/backend/__tests__/properties.test.js
+++ b/property-search-brisbane/backend/__tests__/properties.test.js
@@ -1,8 +1,25 @@
+jest.mock('../services/geocodingService', () => {
+  const actual = jest.requireActual('../services/geocodingService');
+  return {
+    ...actual,
+    geocodeAddress: jest.fn(),
+  };
+});
+
 const request = require('supertest');
 const app = require('../server');
+const {
+  geocodeAddress,
+  GeocodingError,
+  GeocodingNotFoundError,
+} = require('../services/geocodingService');
 
 describe('Property routes', () => {
   describe('GET /properties', () => {
+    beforeEach(() => {
+      geocodeAddress.mockReset();
+    });
+
     it('returns a paginated list of properties', async () => {
       const response = await request(app).get('/properties');
       expect(response.status).toBe(200);
@@ -12,6 +29,8 @@ describe('Property routes', () => {
         pageSize: 20,
       });
       expect(typeof response.body.pagination.total).toBe('number');
+      expect(geocodeAddress).not.toHaveBeenCalled();
+      expect(response.body.locationContext).toBeUndefined();
       response.body.data.forEach((property) => {
         expect(property).toMatchObject({
           id: expect.any(String),
@@ -30,11 +49,27 @@ describe('Property routes', () => {
         .query({ suburb: 'West End', minPrice: 800000, maxPrice: 900000 });
 
       expect(response.status).toBe(200);
+      expect(response.body.locationContext).toBeUndefined();
       expect(response.body.data.length).toBeGreaterThan(0);
       response.body.data.forEach((property) => {
         expect(property.address).toContain('West End');
         expect(property.price).toBeGreaterThanOrEqual(800000);
         expect(property.price).toBeLessThanOrEqual(900000);
+      });
+    });
+
+    it('geocodes an address when provided and includes location context', async () => {
+      geocodeAddress.mockResolvedValue({ latitude: -27.47, longitude: 153.02 });
+
+      const response = await request(app)
+        .get('/properties')
+        .query({ address: ' 1 George St Brisbane ' });
+
+      expect(response.status).toBe(200);
+      expect(geocodeAddress).toHaveBeenCalledWith('1 George St Brisbane');
+      expect(response.body.locationContext).toEqual({
+        searchOrigin: { latitude: -27.47, longitude: 153.02 },
+        radiusMeters: 100,
       });
     });
 
@@ -59,6 +94,34 @@ describe('Property routes', () => {
       expect(response.body.error).toEqual({
         code: 'INVALID_REQUEST',
         message: 'minPrice must be a valid number.',
+      });
+    });
+
+    it('returns a validation error when geocoding fails', async () => {
+      geocodeAddress.mockRejectedValue(new GeocodingError('Mock geocode failure.'));
+
+      const response = await request(app)
+        .get('/properties')
+        .query({ address: '123 Invalid St' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toEqual({
+        code: 'INVALID_REQUEST',
+        message: 'Mock geocode failure.',
+      });
+    });
+
+    it('returns a validation error when geocoding finds no results', async () => {
+      geocodeAddress.mockRejectedValue(new GeocodingNotFoundError());
+
+      const response = await request(app)
+        .get('/properties')
+        .query({ address: 'Unknown Place' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toEqual({
+        code: 'INVALID_REQUEST',
+        message: 'No geocoding results were found for the supplied address.',
       });
     });
   });

--- a/property-search-brisbane/backend/services/geocodingService.js
+++ b/property-search-brisbane/backend/services/geocodingService.js
@@ -1,0 +1,146 @@
+const DEFAULT_RESULT_LIMIT = 1;
+
+class GeocodingError extends Error {
+  constructor(message = 'Unable to complete geocoding request.') {
+    super(message);
+    this.name = 'GeocodingError';
+  }
+}
+
+class GeocodingConfigurationError extends GeocodingError {
+  constructor(message = 'Geocoding service is not configured correctly.') {
+    super(message);
+    this.name = 'GeocodingConfigurationError';
+  }
+}
+
+class GeocodingNotFoundError extends GeocodingError {
+  constructor(message = 'No matching coordinates were found for the supplied address.') {
+    super(message);
+    this.name = 'GeocodingNotFoundError';
+  }
+}
+
+function buildRequestUrl(address) {
+  const endpoint = process.env.GEOCODING_API_URL;
+  const apiKey = process.env.GEOCODING_API_KEY;
+
+  if (!endpoint) {
+    throw new GeocodingConfigurationError('GEOCODING_API_URL must be configured.');
+  }
+
+  let url;
+  try {
+    url = new URL(endpoint);
+  } catch (error) {
+    throw new GeocodingConfigurationError('GEOCODING_API_URL is not a valid URL.');
+  }
+
+  url.searchParams.set('address', address);
+  if (!url.searchParams.has('limit') && DEFAULT_RESULT_LIMIT) {
+    url.searchParams.set('limit', DEFAULT_RESULT_LIMIT);
+  }
+
+  if (apiKey) {
+    // Queensland Government Geocoding API accepts the API key as a query parameter named `key`.
+    url.searchParams.set('key', apiKey);
+  }
+
+  return url;
+}
+
+function extractCoordinates(payload) {
+  if (!payload) {
+    return null;
+  }
+
+  if (Array.isArray(payload.features) && payload.features.length > 0) {
+    for (const feature of payload.features) {
+      const coordinates = feature?.geometry?.coordinates;
+      if (Array.isArray(coordinates) && coordinates.length >= 2) {
+        const [longitude, latitude] = coordinates;
+        return { latitude, longitude };
+      }
+
+      const lat = feature?.properties?.lat ?? feature?.properties?.latitude;
+      const lon = feature?.properties?.lon ?? feature?.properties?.longitude;
+      if (typeof lat === 'number' && typeof lon === 'number') {
+        return { latitude: lat, longitude: lon };
+      }
+    }
+  }
+
+  if (Array.isArray(payload.results) && payload.results.length > 0) {
+    for (const result of payload.results) {
+      const lat = result?.location?.lat ?? result?.location?.latitude ?? result?.lat;
+      const lon = result?.location?.lng ?? result?.location?.longitude ?? result?.lon;
+      if (typeof lat === 'number' && typeof lon === 'number') {
+        return { latitude: lat, longitude: lon };
+      }
+    }
+  }
+
+  if (Array.isArray(payload.locations) && payload.locations.length > 0) {
+    for (const location of payload.locations) {
+      const lat = location?.lat ?? location?.latitude;
+      const lon = location?.lon ?? location?.longitude ?? location?.lng;
+      if (typeof lat === 'number' && typeof lon === 'number') {
+        return { latitude: lat, longitude: lon };
+      }
+    }
+  }
+
+  if (typeof payload.latitude === 'number' && typeof payload.longitude === 'number') {
+    return { latitude: payload.latitude, longitude: payload.longitude };
+  }
+
+  return null;
+}
+
+async function geocodeAddress(address) {
+  if (typeof address !== 'string' || !address.trim()) {
+    throw new GeocodingError('address must be provided as a non-empty string.');
+  }
+
+  const trimmedAddress = address.trim();
+
+  const url = buildRequestUrl(trimmedAddress);
+
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+  } catch (error) {
+    throw new GeocodingError(`Failed to call geocoding service: ${error.message}`);
+  }
+
+  if (!response.ok) {
+    throw new GeocodingError(`Geocoding request failed with status ${response.status}.`);
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new GeocodingError('Geocoding service returned an invalid JSON response.');
+  }
+
+  const coordinates = extractCoordinates(payload);
+  if (!coordinates) {
+    throw new GeocodingNotFoundError();
+  }
+
+  return coordinates;
+}
+
+module.exports = {
+  geocodeAddress,
+  GeocodingError,
+  GeocodingConfigurationError,
+  GeocodingNotFoundError,
+  extractCoordinates,
+  buildRequestUrl,
+};

--- a/property-search-brisbane/backend/services/propertyService.js
+++ b/property-search-brisbane/backend/services/propertyService.js
@@ -8,12 +8,27 @@ class PropertyNotFoundError extends Error {
 }
 
 const PAGE_SIZE = 20;
+const DEFAULT_LOCATION_RADIUS_METERS = 100;
 
 function normaliseSuburb(suburb) {
   return suburb.trim().toLowerCase();
 }
 
-function searchProperties({ suburb, minPrice, maxPrice, page = 1, pageSize = PAGE_SIZE }) {
+function buildLocationContext(coordinates) {
+  if (!coordinates || typeof coordinates.latitude !== 'number' || typeof coordinates.longitude !== 'number') {
+    return null;
+  }
+
+  return {
+    searchOrigin: {
+      latitude: coordinates.latitude,
+      longitude: coordinates.longitude,
+    },
+    radiusMeters: DEFAULT_LOCATION_RADIUS_METERS,
+  };
+}
+
+function searchProperties({ suburb, minPrice, maxPrice, coordinates, page = 1, pageSize = PAGE_SIZE }) {
   let filtered = properties;
 
   if (suburb) {
@@ -35,6 +50,8 @@ function searchProperties({ suburb, minPrice, maxPrice, page = 1, pageSize = PAG
   const end = start + size;
   const results = filtered.slice(start, end);
 
+  const locationContext = buildLocationContext(coordinates);
+
   return {
     results,
     pagination: {
@@ -42,6 +59,7 @@ function searchProperties({ suburb, minPrice, maxPrice, page = 1, pageSize = PAG
       pageSize: size,
       total,
     },
+    locationContext,
   };
 }
 
@@ -60,4 +78,6 @@ module.exports = {
   getPropertyById,
   PropertyNotFoundError,
   PAGE_SIZE,
+  DEFAULT_LOCATION_RADIUS_METERS,
+  buildLocationContext,
 };

--- a/property-search-brisbane/docs/API.md
+++ b/property-search-brisbane/docs/API.md
@@ -41,6 +41,7 @@ Fetch a paginated list of properties filtered by query parameters.
 
 | Name     | Type   | Description                                      |
 |----------|--------|--------------------------------------------------|
+| address  | string | Optional full street address to geocode prior to parcel lookup |
 | suburb   | string | Optional suburb name to filter listings          |
 | minPrice | number | Optional lower bound for price filter            |
 | maxPrice | number | Optional upper bound for price filter            |
@@ -68,9 +69,18 @@ Status: 200 OK
     "page": 1,
     "pageSize": 20,
     "total": 1
+  },
+  "locationContext": {
+    "searchOrigin": {
+      "latitude": -27.4705,
+      "longitude": 153.026
+    },
+    "radiusMeters": 100
   }
 }
 ```
+
+When `address` is provided, the server geocodes the value using the Queensland Government Geocoding API. The resulting latitude and longitude are surfaced under `locationContext.searchOrigin` to describe the parcel query that was executed.
 
 ### GET /properties/{id}
 


### PR DESCRIPTION
## Summary
- add a dedicated geocoding service that calls the Queensland Government API and surfaces helpful error types
- geocode optional property search addresses, attach the resulting location context, and pass coordinates through property service logic
- document the new address parameter and environment variables and expand tests to cover geocoding success and failure paths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddd0842af08327ac0714d1b4d98ced